### PR TITLE
The version is now printed with 'dvdcli version'

### DIFF
--- a/dvdcli/commands.go
+++ b/dvdcli/commands.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 
 	log "github.com/Sirupsen/logrus"
-	"github.com/emccode/rexray/util"
+	"github.com/emccode/dvdcli/util"
 	"github.com/spf13/cobra"
 )
 


### PR DESCRIPTION
This patch fixes an issue where the `dvdcli/commands.go` file was importing `github.com/emccode/rexray/util` instead of `github.com/emccode/dvdcli/util`. Once the import path was fixed, the version printed correctly as the correct version package is now transitively linked.
