### PR TITLE
Enabled volume exist check when mount/unmount/path.

### DIFF
--- a/dvdcli/commands.go
+++ b/dvdcli/commands.go
@@ -78,6 +78,14 @@ var mountCmd = &cobra.Command{
 			opts[nameValue[0]] = nameValue[1]
 		}
 
+		if (checkVolumeExist) {
+			vol, err := driver.Get(volumeName)
+			if err != nil {
+				log.WithField("volumeName", volumeName).Error(err)
+				os.Exit(1)
+			}
+		}
+
 		vol, err := driver.Create(volumeName, opts)
 		if err != nil {
 			log.WithField("volumeName", volumeName).Error(err)
@@ -100,6 +108,15 @@ var unmountCmd = &cobra.Command{
 	Short: "Unmount a volume",
 	Run: func(cmd *cobra.Command, args []string) {
 		initDvd()
+
+		if (checkVolumeExist) {
+			vol, err := driver.Get(volumeName)
+			if err != nil {
+				log.WithField("volumeName", volumeName).Error(err)
+				os.Exit(1)
+			}
+		}
+
 		vol, err := driver.Create(volumeName, nil)
 		if err != nil {
 			log.WithField("volumeName", volumeName).Error(err)
@@ -119,6 +136,15 @@ var pathCmd = &cobra.Command{
 	Short: "Path of a volume",
 	Run: func(cmd *cobra.Command, args []string) {
 		initDvd()
+
+		if (checkVolumeExist) {
+			vol, err := driver.Get(volumeName)
+			if err != nil {
+				log.WithField("volumeName", volumeName).Error(err)
+				os.Exit(1)
+			}
+		}
+
 		vol, err := driver.Create(volumeName, nil)
 		if err != nil {
 			log.WithField("volumeName", volumeName).Error(err)

--- a/dvdcli/flags.go
+++ b/dvdcli/flags.go
@@ -8,6 +8,7 @@ func initFlags() {
 var volumeDriver string
 var volumeName string
 var volumeOpts []string
+var checkVolumeExist bool
 
 func initGlobalFlags() {
 	DvdcliCmd.PersistentFlags().StringVarP(&volumeDriver, "volumedriver", "", "",
@@ -18,4 +19,10 @@ func initGlobalFlags() {
 		"Volume options")
 	mountCmd.Flags().StringSliceVarP(&volumeOpts, "volumeopts", "", []string{},
 		"Volume options")
+	mountCmd.Flags().BoolVarP("checkVolumeExist", "c", false,
+		"Check Volume exist or not")
+	unmountCmd.Flags().BoolVarP("checkVolumeExist", "c", false,
+		"Check Volume exist or not")
+	pathCmd.Flags().BoolVarP("checkVolumeExist", "c", false,
+		"Check Volume exist or not")
 }


### PR DESCRIPTION
The behavior of creating volume implicitly is not a good behavior for customer, please refer to docker/docker#21829 for some discussion in docker.

In https://issues.apache.org/jira/browse/MESOS-4355 , we are trying to leverage dvdcli to integrate docker volume driver to mesos but found that the dvdcli also create volume automatically if the volume does not exist, so we want to introduce a new flag to control the behavior of create volume implicitly.
