### PR TITLE
Updated to use latest Docker v1.11.0 and Volume API

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,14 +4,14 @@
 Docker Volume Driver
 --------------------
 
-As of `Docker` 1.7, there was a Volume Driver API defined that allows `Docker` to work with external storage providers.  The API documentation is available [here](https://github.com/docker/docker/blob/master/docs/extend/index.md).  The existing API has five main features, `Create`, `Remove`, `Mount`, `Unmount`, `Path`.  In order to leverage these features, a Volume Driver is created that manages and orchestrates the API calls to specific storage platforms.  It is these Volume Drivers that this project is using in order to enable Volume Management.  See official plugins [here](https://github.com/docker/docker/blob/master/docs/extend/plugins.md).
+As of `Docker` 1.7, there was a Volume Driver API defined that allows `Docker` to work with external storage providers.  The API documentation is available [here](https://github.com/docker/docker/blob/master/docs/extend/index.md).  As of Docker 1.11.0, the API has seven main features, `Create`, `Remove`, `Mount`, `Unmount`, `Path`, `List`, `Get`.  In order to leverage these features, a Volume Driver is created that manages and orchestrates the API calls to specific storage platforms.  It is these Volume Drivers that this project is using in order to enable Volume Management.  See official plugins [here](https://github.com/docker/docker/blob/master/docs/extend/plugins.md).
 
 
 # Installation
-Installing `dvdcli` couldn't be easier.  The `sh -` portion can be replaced with `sh -s unstable -`, or `sh -s staged` as well.
+Installing `dvdcli` couldn't be easier.  The `sh -` portion can be replaced with `sh -s unstable`, or `sh -s staged` as well.
 
 ```bash
-curl -sSL https://dl.bintray.com/emccode/dvdcli/install | sh -
+curl -sSL https://dl.bintray.com/emccode/dvdcli/install | sh -s stable
 ```
 
 # Downloading
@@ -34,9 +34,27 @@ For `dvdcli`, the command is very similar.
 
 Examples
 --------
-General note about the functionality.  Based on mimicing `Docker` functionality, a create is called at the beginning of each of these operations.  The existing Volume Driver spec expects idempotent operations.
-
 #### Mount a volume
+##### Explicit
+If you would like to ensure a mount operation is interpreted solely as a mount
+the `--explicitCreate=true` flag can be specified.
+
+```
+dvdcli mount --explicitCreate --volumedriver=rexray --volumename=test123456789
+```
+
+##### Implicit
+It is possible to issue a mount command which would create a volume if it does
+not exist as well as mount the volume. This is the default behavior.
+
+```
+dvdcli mount --volumedriver=rexray --volumename=test123456789
+```
+
+#### Implicit with Options
+It is also possible to create implicitly and also specify options for the
+volume that is created.
+
 ```
 dvdcli mount --volumedriver=rexray --volumename=test123456789  \
   --volumeopts=size=5 --volumeopts=iops=150 --volumeopts=volumetype=io1 \
@@ -65,7 +83,21 @@ dvdcli remove --volumedriver=rexray --volumename=test
 dvdcli path --volumedriver=rexray --volumename=test
 ```
 
+#### List availabile volumes
+```
+dvdcli list --volumedriver=rexray
+```
+
+#### Get a specific volume or check whether exists or not
+```
+dvdcli get --volumedriver=rexray --volumename=test
+```
+
 #### Extra Options
+These options are specific to the interpretation of the Volume Driver that
+you are invoking. For [REX-Ray](https://github.com/emccode/rexray) these
+would be valid options.
+
 option|description
 ------|-----------
 size|Size in GB
@@ -79,10 +111,9 @@ snapshotName|Create from an existing snapshot name
 snapshotID|Create from an existing snapshot ID
 
 
-
 EMC {code} - REX-Ray
 -------
-The `REX-Ray` project is a good example of a service that can expose a valid Volume Driver endpoint that can be used and is available [here](https://github.com/emccode/dvdcli).  The options mentioned above are dependent on the Volume Driver.  `REX-Ray` does implement options as listed above.
+The `REX-Ray` project is a good example of a service that can expose a valid Volume Driver endpoint that can be used and is available [here](https://github.com/emccode/rexray).  The options mentioned above are dependent on the Volume Driver.  `REX-Ray` does implement options as listed above.
 
 # Licensing
 ---------

--- a/dvdcli/dvdcli.go
+++ b/dvdcli/dvdcli.go
@@ -17,8 +17,6 @@ func init() {
 	// initUsageTemplates()
 }
 
-const version = "0.1"
-
 func updateLogLevel() {
 	log.SetLevel(log.DebugLevel)
 }

--- a/dvdcli/dvdcli_test.go
+++ b/dvdcli/dvdcli_test.go
@@ -24,6 +24,14 @@ func TestPathCmd(t *testing.T) {
 	pathCmd.Execute()
 }
 
+func TestGetCmd(t *testing.T) {
+	getCmd.Execute()
+}
+
+func TestListCmd(t *testing.T) {
+	listCmd.Execute()
+}
+
 func TestVersionCmd(t *testing.T) {
 	versionCmd.Execute()
 }

--- a/dvdcli/flags.go
+++ b/dvdcli/flags.go
@@ -8,6 +8,7 @@ func initFlags() {
 var volumeDriver string
 var volumeName string
 var volumeOpts []string
+var explicitCreate bool
 
 func initGlobalFlags() {
 	DvdcliCmd.PersistentFlags().StringVarP(&volumeDriver, "volumedriver", "", "",
@@ -18,4 +19,6 @@ func initGlobalFlags() {
 		"Volume options")
 	mountCmd.Flags().StringSliceVarP(&volumeOpts, "volumeopts", "", []string{},
 		"Volume options")
+	mountCmd.Flags().BoolVarP(&explicitCreate, "explicitcreate", "", false,
+		"Explicit create flag to disable creating volumes that don't exist")
 }

--- a/dvdcli/volume.go
+++ b/dvdcli/volume.go
@@ -1,11 +1,1 @@
 package main
-
-type fakeVolume struct {
-	name string
-}
-
-func (vol fakeVolume) Name() string           { return vol.name }
-func (vol fakeVolume) DriverName() string     { return "fake" }
-func (vol fakeVolume) Path() string           { return "path" }
-func (vol fakeVolume) Mount() (string, error) { return "mount", nil }
-func (vol fakeVolume) Unmount() error         { return nil }

--- a/glide.yaml
+++ b/glide.yaml
@@ -3,7 +3,7 @@ import:
   - package: github.com/inconshreveable/mousetrap
     ref:     76626ae9c91c4f2a10f34cad8ce83ea42c93bb75
   - package: github.com/docker/docker
-    ref:     4dfa996cc246691de5e6f509939b96e8643ac228
+    ref:     v1.11.0
   - package: github.com/cpuguy83/go-md2man
     ref:     71acacd42f85e5e82f70a55327789582a5200a90
   - package: github.com/russross/blackfriday
@@ -16,3 +16,5 @@ import:
     ref:     d732ab3a34e6e9e6b5bdac80707c2b6bad852936
   - package: github.com/shurcooL/sanitized_anchor_name
     ref:     244f5ac324cb97e1987ef901a0081a77bfd8e845
+  - package: github.com/docker/go-connections
+    ref:     master


### PR DESCRIPTION
This commit updates the volume API implementation to leverage
the Docker v1.11.0. There was an addition of Get() and List()
methods in prior v1.10. The Get() method now replaces the
call that implicitly created volumes. The Create() method
was used for Path() and other methods prior because there
was no Get() method that returned a volume object.
