### PR TITLE
Fix small error in Makefile when detached

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -102,9 +102,7 @@ else
 		TRAVIS_BRANCH := $(shell git branch | grep '*' | awk '{print $$2}')
 	endif
 endif
-ifeq ($(origin TRAVIS_TAG), undefined)
- 	TRAVIS_TAG := $(TRAVIS_BRANCH)
-else
+ifneq ($(origin TRAVIS_TAG), undefined)
 	ifeq ($(strip $(TRAVIS_TAG)),)
 		TRAVIS_TAG := $(TRAVIS_BRANCH)
 	endif


### PR DESCRIPTION
When you are detached from the branch, you have this error message:
```
# make
SemVer: 0.2.0
RpmVer: 0.2.0
/bin/sh: 1: Syntax error: "(" unexpected
Makefile:322: recipe for target 'version-noarch' failed
make: *** [version-noarch] Error 2
target: deps
  ...installing glide...SUCCESS!
  ...downloading go dependencies...SUCCESS!
target: fmt
  ...formatting dvdcli...SUCCESS!
target: install
  ...installing dvdcli Linux-...SUCCESS!

The dvdcli binary is 8MB and located at:

  /go/bin/dvdcli
```

I've fixed it by not setting the branch:
```
# make
SemVer: 0.2.0+dirty
RpmVer: 0.2.0+dirty
Branch:
Commit: b2f436bcd832fed904ac7d9b94cee7174ff59e18
Formed: Wed, 01 Mar 2017 21:07:37 UTC

target: deps
  ...installing glide...SUCCESS!
  ...downloading go dependencies...SUCCESS!
target: fmt
  ...formatting dvdcli...SUCCESS!
target: install
  ...installing dvdcli Linux-...SUCCESS!

The dvdcli binary is 8MB and located at:

  /go/bin/dvdcli
```