### PR TITLE
Fix import paths after org change

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: go
 
 go:
-  - 1.5.1
+  - 1.7.5
 
 addons:
   apt:
@@ -34,7 +34,7 @@ deploy:
     skip_cleanup: true
     on:
       all_branches: true
-      condition: $TRAVIS_TAG =~ ^$ && ($TRAVIS_REPO_SLUG = 'emccode/dvdcli' || $IGNORE_REPO_SLUG_CONDITION = true) && ($TRAVIS_BRANCH = master || $IGNORE_BRANCH_CONDITION = true)
+      condition: $TRAVIS_TAG =~ ^$ && ($TRAVIS_REPO_SLUG = 'codedellemc/dvdcli' || $IGNORE_REPO_SLUG_CONDITION = true) && ($TRAVIS_BRANCH = master || $IGNORE_BRANCH_CONDITION = true)
 
   - provider: bintray
     file: .bintray-staged-filtered.json
@@ -43,7 +43,7 @@ deploy:
     skip_cleanup: true
     on:
       all_branches: true
-      condition: $TRAVIS_TAG =~ -rc[[:digit:]]+$ && ($TRAVIS_REPO_SLUG = 'emccode/dvdcli' || $IGNORE_REPO_SLUG_CONDITION = true)
+      condition: $TRAVIS_TAG =~ -rc[[:digit:]]+$ && ($TRAVIS_REPO_SLUG = 'codedellemc/dvdcli' || $IGNORE_REPO_SLUG_CONDITION = true)
 
   - provider: bintray
     file: .bintray-stable-filtered.json
@@ -52,10 +52,15 @@ deploy:
     skip_cleanup: true
     on:
       all_branches: true
-      condition: $TRAVIS_TAG =~ ^v?[[:digit:]]+\.[[:digit:]]+\.[[:digit:]]$ && ($TRAVIS_REPO_SLUG = 'emccode/dvdcli' || $IGNORE_REPO_SLUG_CONDITION = true)
+      condition: $TRAVIS_TAG =~ ^v?[[:digit:]]+\.[[:digit:]]+\.[[:digit:]]$ && ($TRAVIS_REPO_SLUG = 'codedellemc/dvdcli' || $IGNORE_REPO_SLUG_CONDITION = true)
 
 cache:
   apt: true
   directories:
     - $GOPATH/pkg
     - $HOME/.opt
+
+sudo: required
+
+services:
+  - docker

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,17 @@
 # configure make
-export MAKEFLAGS := $(MAKEFLAGS) --no-print-directory -k
+export MAKEFLAGS := $(MAKEFLAGS) --no-print-directory -k -j1
+
+# MAKE_LOG_LEVEL can be 0=quiet, 1=error, 2=verbose
+MAKE_LOG_LEVEL ?= 0
+ifeq ($(MAKE_LOG_LEVEL),0)
+	MAKE_LOG_FD := \&> /dev/null
+else
+ifeq ($(MAKE_LOG_LEVEL),1)
+	MAKE_LOG_FD := 1> /dev/null
+else
+	MAKE_LOG_FD :=
+endif
+endif
 
 # store the current working directory
 CWD := $(shell pwd)
@@ -91,7 +103,7 @@ else
 	endif
 endif
 ifeq ($(origin TRAVIS_TAG), undefined)
-	TRAVIS_TAG := $(TRAVIS_BRANCH)
+ 	TRAVIS_TAG := $(TRAVIS_BRANCH)
 else
 	ifeq ($(strip $(TRAVIS_TAG)),)
 		TRAVIS_TAG := $(TRAVIS_BRANCH)
@@ -145,7 +157,7 @@ V_RPM_SEMVER := $(subst -,+,$(V_SEMVER))
 GOFLAGS := $(GOFLAGS)
 GLIDE := $(GOPATH)/bin/glide
 NV := $$($(GLIDE) novendor)
-BASEPKG := github.com/emccode/dvdcli
+BASEPKG := github.com/codedellemc/dvdcli
 BASEDIR := $(GOPATH)/src/$(BASEPKG)
 BASEDIR_NAME := $(shell basename $(BASEDIR))
 BASEDIR_PARENTDIR := $(shell dirname $(BASEDIR))
@@ -158,7 +170,7 @@ LDF_SHA_LONG := -X $(VERSIONPKG).ShaLong=$(V_SHA_LONG)
 LDF_ARCH = -X $(VERSIONPKG).Arch=$(V_OS_ARCH)
 LDFLAGS = -ldflags "$(LDF_SEMVER) $(LDF_BRANCH) $(LDF_EPOCH) $(LDF_SHA_LONG) $(LDF_ARCH)"
 RPMBUILD := $(CWD)/.rpmbuild
-EMCCODE := $(GOPATH)/src/github.com/emccode
+CODEDELLEMC := $(GOPATH)/src/github.com/codedellemc
 PRINT_STATUS = export EC=$$?; cd $(CWD); if [ "$$EC" -eq "0" ]; then printf "SUCCESS!\n"; else exit $$EC; fi
 STAT_FILE_SIZE = stat --format '%s' $$FILE 2> /dev/null || stat -f '%z' $$FILE 2> /dev/null
 

--- a/dvdcli.spec
+++ b/dvdcli.spec
@@ -7,9 +7,9 @@ Version: %{v_semver}
 Release: 1
 License: Apache License
 Group: Applications/Storage
-#Source: https://github.com/emccode/dvdcli/archive/master.zip
-URL: https://github.com/emccode/dvdcli
-Vendor: EMC{code}
+#Source: https://github.com/codedellemc/dvdcli/archive/master.zip
+URL: https://github.com/codedellemc/dvdcli
+Vendor: {code} by Dell EMC
 Packager: Andrew Kutz <sakutz@gmail.com>
 BuildArch: %{v_arch}
 BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}

--- a/dvdcli/commands.go
+++ b/dvdcli/commands.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 
 	log "github.com/Sirupsen/logrus"
-	"github.com/emccode/dvdcli/util"
+	"github.com/codedellemc/dvdcli/util"
 	"github.com/spf13/cobra"
 )
 

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,4 +1,4 @@
-package: github.com/emccode/dvdcli
+package: github.com/codedellemc/dvdcli
 import:
   - package: github.com/inconshreveable/mousetrap
     ref:     76626ae9c91c4f2a10f34cad8ce83ea42c93bb75

--- a/util/util.go
+++ b/util/util.go
@@ -7,7 +7,7 @@ import (
 	"path/filepath"
 
 	"github.com/bugsnag/osext"
-	version "github.com/emccode/dvdcli/version_info"
+	version "github.com/codedellemc/dvdcli/version_info"
 )
 
 var thisExeAbsPath string

--- a/util/util_test.go
+++ b/util/util_test.go
@@ -22,14 +22,14 @@ func TestGetPathPaths(t *testing.T) {
 func TestGetThisPathParts(t *testing.T) {
 	dirPath, fileName, absPath := GetThisPathParts()
 	if !strings.Contains(dirPath,
-		"github.com/emccode/dvdcli/util/_test") {
+		"github.com/codedellemc/dvdcli/util/_test") {
 		t.Fail()
 	}
 	if fileName != "util.test" {
 		t.Fail()
 	}
 	if !strings.Contains(absPath,
-		"github.com/emccode/dvdcli/util/_test/util.test") {
+		"github.com/codedellemc/dvdcli/util/_test/util.test") {
 		t.Fail()
 	}
 }


### PR DESCRIPTION
Fix the go files after the move from emccode to codedellemc orgs. Broke all the import paths for the project.